### PR TITLE
node_modules folder should be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
All dependency information is already defined in package.json. To install the dependencies, run `npm install`.